### PR TITLE
If using `keppArrayName`, self closing tags cause XML serialization to fail

### DIFF
--- a/src/main/java/net/sf/json/xml/XMLSerializer.java
+++ b/src/main/java/net/sf/json/xml/XMLSerializer.java
@@ -29,7 +29,6 @@ import nu.xom.Document;
 import nu.xom.Element;
 import nu.xom.Elements;
 import nu.xom.Node;
-import nu.xom.ProcessingInstruction;
 import nu.xom.Serializer;
 import nu.xom.Text;
 import org.apache.commons.lang.ArrayUtils;
@@ -988,6 +987,12 @@ public class XMLSerializer {
          }
          if( isSameElementNameInArray ){
             JSONObject result = new JSONObject();
+            // in the case of a self-closing tag, arrayName will be null
+            // and this will throw an error if we return the empty array
+            // then it will be added correctly to the result
+            if (arrayName == null) {
+                return jsonArray;
+            }
             result.put( arrayName, jsonArray );
             return result;
          }

--- a/src/test/java/net/sf/json/xml/TestXMLSerializer_reads.java
+++ b/src/test/java/net/sf/json/xml/TestXMLSerializer_reads.java
@@ -45,7 +45,17 @@ public class TestXMLSerializer_reads extends TestCase {
       Assertions.assertEquals( expected, actual );
    }
 
-   public void testNullObjectArray_noTypeHintsCompatibility() {
+    public void testSelfClosingTagsWithKeepArrayNames() {
+        String xml = "<root><a><b /></a></root>";
+        xmlSerializer.setKeepArrayName(true);
+        JSON actual = xmlSerializer.read( xml );
+        xmlSerializer.setKeepArrayName(false);
+        JSON expected = JSONObject.fromObject( "{\"a\": { \"b\": [] } }" );
+        Assertions.assertEquals( expected, actual );
+    }
+
+
+    public void testNullObjectArray_noTypeHintsCompatibility() {
       String xml = "<a><e json_class=\"object\" json_null=\"true\"/><e json_class=\"object\" json_null=\"true\"/></a>";
       xmlSerializer.setTypeHintsCompatibility( false );
       JSON actual = xmlSerializer.read( xml );


### PR DESCRIPTION
If self closing tags are encountered when `keepArrayName` is set to `true` XML serialization fails. For example:

```
        String xml = "<root><a><b /></a></root>";
        xmlSerializer.setKeepArrayName(true);
        JSON actual = xmlSerializer.read( xml );
```

Will cause:

```
net.sf.json.JSONException: java.lang.IllegalArgumentException: key is null.
    at net.sf.json.xml.XMLSerializer.read(XMLSerializer.java:380)
    at net.sf.json.xml.TestXMLSerializer_reads.testSelfClosingTagsWithKeepArrayNames(TestXMLSerializer_reads.java:51)
       ...10 more
Caused by: java.lang.IllegalArgumentException: key is null.
    at net.sf.json.JSONObject.put(JSONObject.java:2297)
    at net.sf.json.xml.XMLSerializer.processArrayElement(XMLSerializer.java:996)
    at net.sf.json.xml.XMLSerializer.setValue(XMLSerializer.java:1407)
    at net.sf.json.xml.XMLSerializer.processObjectElement(XMLSerializer.java:1236)
    at net.sf.json.xml.XMLSerializer.setValue(XMLSerializer.java:1409)
    at net.sf.json.xml.XMLSerializer.processObjectElement(XMLSerializer.java:1236)
    at net.sf.json.xml.XMLSerializer.read(XMLSerializer.java:371)
    ... 22 more
```

---
## To give more context

By default the XMLSerializer will turn this:

```
<root>
  <child>
    <a>1</a>
    <a>2</a>
    <a>3</a>
  </child>
</root>
```

Into this:

```
{
  "child": ["1", "2", "3"]
}
```

(running version 2.4.1)

When using `xmlSerializer.setKeepArrayName(true)` the result looks like:

```
{
  "child": {
     "a": ["1", "2", "3"]
  }
}
```
