### PR TITLE
Implemented enhancement #16

### DIFF
--- a/src/test/java/org/kordamp/json/xml/AllTests.java
+++ b/src/test/java/org/kordamp/json/xml/AllTests.java
@@ -37,6 +37,7 @@ public class AllTests extends TestSuite {
         suite.addTest(new TestSuite(TestXmlWithEntity.class));
         suite.addTest(new TestSuite(TestIdmlParsing.class));
         suite.addTest(new TestSuite(TestElementShouldNotBeArray.class));
+        suite.addTest(new TestSuite(TestForcedArrayElementFlag.class));
 
         return suite;
     }

--- a/src/test/java/org/kordamp/json/xml/TestForcedArrayElementFlag.java
+++ b/src/test/java/org/kordamp/json/xml/TestForcedArrayElementFlag.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2006-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kordamp.json.xml;
+
+import junit.framework.TestCase;
+import org.kordamp.json.JSONObject;
+
+import java.util.HashSet;
+import java.util.Set;
+
+
+/**
+ * @author Michel Racic
+ */
+public class TestForcedArrayElementFlag extends TestCase {
+
+
+    /**
+     * Should get an array without the list in this case.
+     * With the list it needs to have the same behaviour.
+     */
+    public void test_same_elements_should_be_forced_array() {
+        final XMLSerializer xmlSerializer = new XMLSerializer();
+        xmlSerializer.setKeepCData(true);
+        Set<String> arrayElements = new HashSet<String>();
+        arrayElements.add("Properties");
+        JSONObject actual = (JSONObject) xmlSerializer.read("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+                "<Document DOMVersion=\"8.0\" Self=\"d\">" +
+                "<TinDocumentDataObject>\n" +
+                "<Properties>\n" +
+                "<GaijiRefMaps><![CDATA[/////wAAAAAAAAAA]]></GaijiRefMaps>\n" +
+                "<GaijiRefMaps><![CDATA[/////wBBBBBBBBBB]]></GaijiRefMaps>\n" +
+                "</Properties>\n" +
+                "</TinDocumentDataObject>\n" +
+                "</Document>\n");
+
+        String expectedJsonString = "{@DOMVersion:\"8.0\", @Self:\"d\", TinDocumentDataObject:{" +
+                        "Properties:[\"/////wAAAAAAAAAA\",\"/////wBBBBBBBBBB\"]}}";
+        final JSONObject expected = JSONObject.fromObject(expectedJsonString);
+
+        assertEquals(expected, actual);
+    }
+
+    public void test_different_elements_should_be_forced_array_with_log_warning() {
+        final XMLSerializer xmlSerializer = new XMLSerializer();
+        xmlSerializer.setKeepCData(true);
+        Set<String> arrayElements = new HashSet<String>();
+        arrayElements.add("Properties");
+        xmlSerializer.setForcedArrayParents(arrayElements);
+        JSONObject actual = (JSONObject) xmlSerializer.read("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+                "<Document DOMVersion=\"8.0\" Self=\"d\">" +
+                "<TinDocumentDataObject>\n" +
+                "<Properties>\n" +
+                "<GaijiRefMaps><![CDATA[/////wAAAAAAAAAA]]></GaijiRefMaps>\n" +
+                "<ForcedArrayElement><![CDATA[/////wBBBBBBBBBB]]></ForcedArrayElement>\n" +
+                "</Properties>\n" +
+                "</TinDocumentDataObject>\n" +
+                "</Document>\n");
+
+        final JSONObject expected = JSONObject.fromObject("{@DOMVersion:\"8.0\", @Self:\"d\", TinDocumentDataObject:{" +
+                "Properties:[\"/////wAAAAAAAAAA\",\"/////wBBBBBBBBBB\"] } }");
+
+        assertEquals(expected, actual);
+
+        // Check if warning appears in log
+        //TODO Check log, find how to do it?
+    }
+
+    public void test_single_element_should_be_forced_array() {
+        final XMLSerializer xmlSerializer = new XMLSerializer();
+        xmlSerializer.setKeepCData(true);
+        Set<String> arrayElements = new HashSet<String>();
+        arrayElements.add("Properties");
+        xmlSerializer.setForcedArrayParents(arrayElements);
+        JSONObject actual = (JSONObject) xmlSerializer.read("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+                "<Document DOMVersion=\"8.0\" Self=\"d\">" +
+                "<TinDocumentDataObject>\n" +
+                "<Properties>\n" +
+                "<GaijiRefMaps><![CDATA[/////wAAAAAAAAAA]]></GaijiRefMaps>\n" +
+                "</Properties>\n" +
+                "</TinDocumentDataObject>\n" +
+                "</Document>\n");
+
+        final JSONObject expected = JSONObject.fromObject("{@DOMVersion:\"8.0\", @Self:\"d\", TinDocumentDataObject:{" +
+                "Properties:[\"/////wAAAAAAAAAA\"] } }");
+
+        assertEquals(expected, actual);
+    }
+
+    public void test_no_child_element_should_be_forced_empty_array() {
+            final XMLSerializer xmlSerializer = new XMLSerializer();
+            xmlSerializer.setKeepCData(true);
+            Set<String> arrayElements = new HashSet<String>();
+            arrayElements.add("Properties");
+            xmlSerializer.setForcedArrayParents(arrayElements);
+            JSONObject actual = (JSONObject) xmlSerializer.read("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+                    "<Document DOMVersion=\"8.0\" Self=\"d\">" +
+                    "<TinDocumentDataObject>\n" +
+                    "<Properties>\n" +
+                    "</Properties>\n" +
+                    "</TinDocumentDataObject>\n" +
+                    "</Document>\n");
+
+            final JSONObject expected = JSONObject.fromObject("{@DOMVersion:\"8.0\", @Self:\"d\", TinDocumentDataObject:{" +
+                    "Properties:[] } }");
+
+            assertEquals(expected, actual);
+        }
+
+    public void test_single_empty_child_element_should_be_forced_empty_array() {
+                final XMLSerializer xmlSerializer = new XMLSerializer();
+                xmlSerializer.setKeepCData(true);
+                Set<String> arrayElements = new HashSet<String>();
+                arrayElements.add("Properties");
+                xmlSerializer.setForcedArrayParents(arrayElements);
+                JSONObject actual = (JSONObject) xmlSerializer.read("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+                        "<Document DOMVersion=\"8.0\" Self=\"d\">" +
+                        "<TinDocumentDataObject>\n" +
+                        "<Properties>\n" +
+                        "<GaijiRefMaps></GaijiRefMaps>\n" +
+                        "</Properties>\n" +
+                        "</TinDocumentDataObject>\n" +
+                        "</Document>\n");
+
+                final JSONObject expected = JSONObject.fromObject("{@DOMVersion:\"8.0\", @Self:\"d\", TinDocumentDataObject:{" +
+                        "Properties:[null] } }");
+
+                assertEquals(expected, actual);
+            }
+
+    public void test_single_terminating_empty_child_element_should_be_forced_empty_array() {
+                    final XMLSerializer xmlSerializer = new XMLSerializer();
+                    xmlSerializer.setKeepCData(true);
+                    Set<String> arrayElements = new HashSet<String>();
+                    arrayElements.add("Properties");
+                    xmlSerializer.setForcedArrayParents(arrayElements);
+                    JSONObject actual = (JSONObject) xmlSerializer.read("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+                            "<Document DOMVersion=\"8.0\" Self=\"d\">" +
+                            "<TinDocumentDataObject>\n" +
+                            "<Properties>\n" +
+                            "<GaijiRefMaps />\n" +
+                            "</Properties>\n" +
+                            "</TinDocumentDataObject>\n" +
+                            "</Document>\n");
+
+                    final JSONObject expected = JSONObject.fromObject("{@DOMVersion:\"8.0\", @Self:\"d\", TinDocumentDataObject:{" +
+                            "Properties:[null] } }");
+
+                    assertEquals(expected, actual);
+                }
+}


### PR DESCRIPTION
Implemented list of elements which enforce creation of an array from
it’s childs even if there is no, only one or multiple elements with
different name in it.
In case of different name, information gets lost but it will be done
with a log warning.
