### PR TITLE
Reduce memory allocations and improve performance in `JSONObject`

### DIFF
--- a/subprojects/json-lib-core/src/main/java/org/kordamp/json/JSONObject.java
+++ b/subprojects/json-lib-core/src/main/java/org/kordamp/json/JSONObject.java
@@ -656,7 +656,7 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
                 String key;
                 Object value;
 
-                if (tokener.matches("null.*")) {
+                if (tokener.startsWith("null")) {
                     fireObjectStartEvent(jsonConfig);
                     fireObjectEndEvent(jsonConfig);
                     return new JSONObject(true);

--- a/subprojects/json-lib-core/src/main/java/org/kordamp/json/util/JSONTokener.java
+++ b/subprojects/json-lib-core/src/main/java/org/kordamp/json/util/JSONTokener.java
@@ -114,6 +114,10 @@ public class JSONTokener {
             .matches(str);
     }
 
+    public boolean startsWith(String prefix) {
+        return this.mySource.startsWith(prefix, this.myIndex);
+    }
+
     /**
      * Determine if the source string still contains characters that next() can
      * consume.

--- a/subprojects/json-lib-core/src/test/java/org/kordamp/json/util/TestJSONTokener.java
+++ b/subprojects/json-lib-core/src/test/java/org/kordamp/json/util/TestJSONTokener.java
@@ -75,6 +75,20 @@ public class TestJSONTokener extends TestCase {
         }
     }
 
+    public void testStartsWith() {
+        assertFalse(new JSONTokener("").startsWith("null"));
+        assertFalse(new JSONTokener("n").startsWith("null"));
+        assertFalse(new JSONTokener("nu").startsWith("null"));
+        assertFalse(new JSONTokener("nul").startsWith("null"));
+        assertTrue(new JSONTokener("null").startsWith("null"));
+        assertTrue(new JSONTokener("nulll").startsWith("null"));
+        assertFalse(new JSONTokener("nn").startsWith("null"));
+        assertFalse(new JSONTokener("nnu").startsWith("null"));
+        assertFalse(new JSONTokener("nnul").startsWith("null"));
+        assertFalse(new JSONTokener("nnull").startsWith("null"));
+        assertFalse(new JSONTokener("nnulll").startsWith("null"));
+    }
+
     public void testReset() {
         JSONTokener tok = new JSONTokener("abc");
         tok.next();


### PR DESCRIPTION
Parsing https://updates.jenkins.io/update-center.json is extremely slow (hundreds of times slower than `jq`, for example). It consistently takes about 8 seconds and allocates about 170 GiB of RAM over the course of the parsing procedure. Profiling showed lots of regular expression compilation like

```
  java.lang.Thread.State: RUNNABLE
	at java.util.regex.Pattern.compile(java.base@11.0.5/Pattern.java:1757)
	at java.util.regex.Pattern.<init>(java.base@11.0.5/Pattern.java:1428)
	at java.util.regex.Pattern.compile(java.base@11.0.5/Pattern.java:1068)
	at net.sf.json.regexp.JdkRegexpMatcher.<init>(JdkRegexpMatcher.java:38)
	at net.sf.json.regexp.JdkRegexpMatcher.<init>(JdkRegexpMatcher.java:31)
	at net.sf.json.regexp.RegexpUtils.getMatcher(RegexpUtils.java:39)
	at net.sf.json.util.JSONTokener.matches(JSONTokener.java:111)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:912)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:156)
	at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:348)
	at net.sf.json.JSONArray._fromJSONTokener(JSONArray.java:1131)
	at net.sf.json.JSONArray.fromObject(JSONArray.java:125)
	at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:351)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:955)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:156)
	at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:348)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:955)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:156)
	at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:348)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:955)
	at net.sf.json.JSONObject._fromString(JSONObject.java:1145)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:162)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:132)
```

and string allocation like

```
   java.lang.Thread.State: RUNNABLE
	at java.lang.String.<init>(String.java:207)
	at java.lang.String.substring(String.java:1933)
	at net.sf.json.util.JSONTokener.matches(JSONTokener.java:110)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:912)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:156)
	at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:348)
	at net.sf.json.JSONArray._fromJSONTokener(JSONArray.java:1131)
	at net.sf.json.JSONArray.fromObject(JSONArray.java:125)
	at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:351)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:955)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:156)
	at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:348)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:955)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:156)
	at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:348)
	at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:955)
	at net.sf.json.JSONObject._fromString(JSONObject.java:1145)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:162)
	at net.sf.json.JSONObject.fromObject(JSONObject.java:132)
```

There are two issues here: repeatedly compiling a pattern where a simple `.startsWith("null")` would have sufficed, and repeatedly copying a massive string just to search a few characters in it. See flame graphs before and after.

![before](https://github.com/jenkinsci/json-lib/assets/29850/4ef3e19c-ea10-443b-9ba3-fb548dbe5623)

![after](https://github.com/jenkinsci/json-lib/assets/29850/639408aa-ff28-48fc-bda0-732c5cece146)

I added a new unit test. This has also been shipping in production in our fork of `json-lib` to Jenkins users in 2.456 since May without any reported issues.