### PR TITLE
Fix SpotBugs violation

### DIFF
--- a/subprojects/json-lib-core/src/main/java/org/kordamp/json/JsonConfig.java
+++ b/subprojects/json-lib-core/src/main/java/org/kordamp/json/JsonConfig.java
@@ -547,7 +547,7 @@ public class JsonConfig {
             }
             this.collectionType = collectionType;
         } else {
-            collectionType = DEFAULT_COLLECTION_TYPE;
+            this.collectionType = DEFAULT_COLLECTION_TYPE;
         }
     }
 


### PR DESCRIPTION
`[ERROR] High: Dead store to collectionType rather than field with same name in net.sf.json.JsonConfig.setCollectionType(Class) [net.sf.json.JsonConfig] At JsonConfig.java:[line 1068] DLS_DEAD_LOCAL_STORE_SHADOWS_FIELD`